### PR TITLE
Add support for custom dependency types

### DIFF
--- a/collection-sig.rkt
+++ b/collection-sig.rkt
@@ -1,6 +1,6 @@
-#lang mzscheme
+#lang racket/base
 
-(require mzlib/unit)
+(require racket/unit)
 
 (provide make:collection^)
 

--- a/collection-unit.rkt
+++ b/collection-unit.rkt
@@ -1,8 +1,6 @@
-#lang mzscheme
+#lang racket/base
 
-(require mzlib/unit
-         mzlib/list
-         mzlib/file
+(require racket/unit
          "collection-sig.rkt"
          "make-sig.rkt"
          compiler/sig

--- a/collection.rkt
+++ b/collection.rkt
@@ -1,6 +1,6 @@
-#lang mzscheme
+#lang racket/base
 
-(require mzlib/unit
+(require racket/unit
          dynext/file-sig
          dynext/file
          compiler/sig

--- a/info.rkt
+++ b/info.rkt
@@ -1,5 +1,7 @@
 #lang info
 
+(define version "1.1")
+
 (define collection "make")
 
 (define scribblings '(("make.scrbl" (multi-page) (tool-library))))

--- a/main.rkt
+++ b/main.rkt
@@ -1,4 +1,4 @@
-#lang scheme/base
+#lang racket/base
 
 (require "make.rkt")
 (provide (all-from-out "make.rkt"))

--- a/make-sig.rkt
+++ b/make-sig.rkt
@@ -1,4 +1,4 @@
-#lang scheme/signature
+#lang racket/signature
 
 make/proc
 make-print-checking

--- a/make-unit.rkt
+++ b/make-unit.rkt
@@ -1,6 +1,7 @@
 #lang racket/unit
 
-(require "make-sig.rkt")
+(require "make-sig.rkt"
+         "private/dependency.rkt")
 
 (import)
 (export make^)
@@ -11,15 +12,19 @@
 (define make-notify-handler    (make-parameter void))
 
 (define-struct line (targets      ; (list-of string)
-                     dependencies ; (list-of string)
+                     dependencies ; (list-of dependency)
                      command))    ; (union thunk #f)
 (define-struct (exn:fail:make exn:fail) (target orig-exn))
 
 ;; check-spec : TST -> (non-empty-list-of line)
 ;; throws an error on bad input
 (define (spec->lines spec)
-  (define (->strings xs)
-    (map (lambda (x) (if (path? x) (path->string x) x)) xs))
+  (define (path/string/dependency? x)
+    (or (path-string? x) (dependency? x)))
+  (define (->dependency x)
+    (if (or (string? x) (path? x)) (file x) x))
+  (define (->dependency/string x)
+    (if (or (path? x)) (file x) x))
   (define (err s p) (error 'make/proc "~a: ~e" s p))
   (unless (and (list? spec) (pair? spec))
     (err "specification is not a non-empty list" spec))
@@ -31,87 +36,95 @@
            [deps (cadr line)]
            [thunk (and (pair? (cddr line)) (caddr line))])
       (define (err s p) (error 'make/proc "~a: ~e for line: ~a" s p name))
-      (unless (andmap path-string? tgts)
-        (err "line does not start with a path/string or list of paths/strings"
+      (unless (andmap path/string/dependency? tgts)
+        (err "line does not start with a path/string/dependency or list of paths/string/dependencies"
              line))
       (unless (list? deps) (err "second part of line is not a list" deps))
       (for ([dep deps])
-        (unless (path-string? dep)
-          (err "dependency item is not a path/string" dep)))
+        (unless (path/string/dependency? dep)
+          (err "dependency item is not a path/string/dependency" dep)))
       (unless (or (not thunk)
                   (and (procedure? thunk) (procedure-arity-includes? thunk 0)))
         (err "command part of line is not a thunk" thunk))
-      (make-line (->strings tgts) (->strings deps) thunk))))
+      (make-line (map ->dependency tgts) (map ->dependency/string deps) thunk))))
 
-;; (union path-string (vector-of path-string) (list-of path-string))
-;; -> (list-of string)
+;; (union path/string/dep (vector-of path/string/dep) (list-of path/string/dep))
+;; -> (list-of (union string dependency))
 ;; throws an error on bad input
 (define (argv->args x)
   (let ([args (cond [(list? x) x]
                     [(vector? x) (vector->list x)]
                     [else (list x)])])
     (map (lambda (a)
-           (cond [(string? a) a]
-                 [(path? a) (path->string a)]
+           (cond [(or (string? a) (dependency? a)) a]
+                 [(path? a) (file a)]
                  [else (raise-type-error
-                        'make/proc "path/string or path/string vector or list"
+                        'make/proc "path/string/dependency or path/string/dependency vector or list"
                         x)]))
          args)))
 
-;; path-date : path-string -> (union integer #f)
-(define (path-date p)
-  (and (or (directory-exists? p) (file-exists? p))
-       (file-or-directory-modify-seconds p)))
-
 ;; make/proc :
-;; spec (union path-string (vector-of path-string) (list-of path-string))
+;; spec (union path/string/dep (vector-of path/string/dep) (list-of path/string/dep))
 ;; -> void
 ;; effect : make, according to spec and argv. See docs for details
 (define (make/proc spec [argv '()])
   (define made null)
   (define lines (spec->lines spec))
   (define args (argv->args argv))
-  (define (make-file s indent)
-    (define line
-      (findf (lambda (line)
-               (ormap (lambda (s1) (string=? s s1)) (line-targets line)))
-             lines))
-    (define date (path-date s))
+  (define (->string s)
+    (if (string? s) s (dependency->string s)))
+  (define (make-dependency s indent)
+    (define dep+line
+      (for/or ([line (in-list lines)])
+        (let ([dep (for/or ([dep (in-list (line-targets line))])
+                     (and (or (equal? s dep)
+                              (and (string? s)
+                                   (string=? s (dependency-label dep))))
+                          dep))])
+          (and dep (cons dep line)))))
+    (define-values [dep line] (if dep+line
+                                  (values (car dep+line) (cdr dep+line))
+                                  (values (and (dependency? s) s) #f)))
+    (define date (and dep (dependency-modification-timestamp dep)))
     (when (and (make-print-checking) (or line (make-print-dep-no-line)))
-      (printf "make: ~achecking ~a\n" indent s)
+      (printf "make: ~achecking ~a\n" indent (->string s))
       (flush-output))
     (if (not line)
-      (unless date (error 'make "don't know how to make ~a" s))
+      (unless date (error 'make "don't know how to make ~a" (->string s)))
       (let* ([deps (line-dependencies line)]
              [command (line-command line)]
              [indent+ (string-append indent " ")]
-             [dep-dates (for/list ([d deps])
-                          (make-file d indent+)
-                          (or (path-date d)
-                              (error 'make "dependancy ~a was not made\n" d)))]
+             [dep-dates (for/list ([s* deps])
+                          (define dep* (make-dependency s* indent+))
+                          (or (dependency-modification-timestamp dep*)
+                              (error 'make "dependency ~a was not made\n"
+                                     (dependency->string dep*))))]
              [reason (or (not date)
                          (ormap (lambda (dep ddate) (and (> ddate date) dep))
                                 deps dep-dates))])
         (when (and reason command)
-          (set! made (cons s made))
-          ((make-notify-handler) s)
+          (set! made (cons dep made))
+          ((make-notify-handler) dep)
           (printf "make: ~amaking ~a~a\n"
                   (if (make-print-checking) indent "")
-                  s
+                  (dependency->string dep)
                   (cond [(not (make-print-reasons)) ""]
-                        [(not date) (format " because ~a does not exist" s)]
-                        [else (format " because ~a changed" reason)]))
+                        [(not date) (format " because ~a does not exist" (dependency->string dep))]
+                        [else (format " because ~a changed" (->string reason))]))
           (flush-output)
           (with-handlers ([exn:fail?
                            (lambda (exn)
                              (raise (make-exn:fail:make
                                      (format "make: failed to make ~a; ~a"
-                                             s (exn-message exn))
+                                             (dependency->string dep) (exn-message exn))
                                      (exn-continuation-marks exn)
                                      (line-targets line)
                                      exn)))])
-            (command))))))
+            (dependency-pre-build dep)
+            (command)
+            (dependency-post-build dep)))))
+    dep)
   (for ([f (if (null? args) (list (car (line-targets (car lines)))) args)])
-    (make-file f ""))
-  (for ([item (reverse made)]) (printf "make: made ~a\n" item))
+    (make-dependency f ""))
+  (for ([item (reverse made)]) (printf "make: made ~a\n" (dependency->string item)))
   (flush-output))

--- a/make-unit.rkt
+++ b/make-unit.rkt
@@ -1,4 +1,4 @@
-#lang scheme/unit
+#lang racket/unit
 
 (require "make-sig.rkt")
 

--- a/make.rkt
+++ b/make.rkt
@@ -1,6 +1,7 @@
-#lang mzscheme
+#lang racket/base
 
-(require mzlib/unit
+(require (for-syntax racket/base)
+         racket/unit
          "make-sig.rkt"
          "make-unit.rkt")
 

--- a/make.rkt
+++ b/make.rkt
@@ -3,13 +3,14 @@
 (require (for-syntax racket/base)
          racket/unit
          "make-sig.rkt"
-         "make-unit.rkt")
+         "make-unit.rkt"
+         "private/dependency.rkt")
 
 (define-values/invoke-unit/infer make@)
 
 (provide-signature-elements make^)
 
-(provide make)
+(provide make (all-from-out "private/dependency.rkt"))
 
 (define-syntax make
   (lambda (stx)

--- a/make.scrbl
+++ b/make.scrbl
@@ -1,6 +1,5 @@
-#lang scribble/doc
-@(require scribble/manual
-          (for-label scheme/base scheme/contract scheme/unit
+#lang scribble/manual
+@(require (for-label scheme/base scheme/contract scheme/unit
                      make make/make-unit make/make-sig
                      make/collection make/collection-sig make/collection-unit
                      dynext/file-sig compiler/sig))
@@ -207,6 +206,10 @@ that a command thunk is called. The default is @racket[#t].}
 
 @subsection[#:tag "make-signature"]{Signature}
 
+@margin-note{@racket[make^] and @racket[make@] are deprecated.
+They exist for backward-compatibility and will likely be removed in
+the future. New code should use the @racketmodname[make] module.}
+
 @defmodule[make/make-sig]
 
 @defsignature[make^ ()]{
@@ -382,6 +385,11 @@ Compilation is performed as with @exec{raco make} (see
 @|raco-manual|).}
 
 @subsection{Signature}
+
+@margin-note{@racket[make:collection^] and @racket[make:collection@] are
+deprecated. They exist for backward-compatibility and will likely be
+removed in the future. New code should use the
+@racketmodname[make/collection] module.}
 
 @defmodule[make/collection-sig]
 

--- a/private/dependency.rkt
+++ b/private/dependency.rkt
@@ -1,0 +1,75 @@
+#lang racket/base
+
+(require racket/contract
+         racket/generic)
+
+(provide gen:dependency dependency? dependency/c
+         dependency-modification-timestamp dependency->string dependency-label
+         dependency-pre-build dependency-post-build
+         (contract-out [file (path-string? . -> . any)]
+                       [label (string? . -> . any)]))
+
+(define-generics dependency
+  ; dependency -> (or/c exact-integer #f)
+  (dependency-modification-timestamp dependency)
+  ; dependency -> string
+  (dependency->string dependency)
+  ; dependency -> string
+  (dependency-label dependency)
+
+  ; dependency -> any
+  (dependency-pre-build dependency)
+  (dependency-post-build dependency)
+
+  #:defined-predicate dependency-method-implemented?
+
+  #:fallbacks
+  [(define/generic -dependency->string dependency->string)
+   (define/generic -dependency-label dependency-label)
+   (define (dependency->string dep)
+     (if (dependency-method-implemented? dep 'dependency-label)
+         (-dependency-label dep)
+         (format "~a" dep)))
+   (define (dependency-label dep)
+     (-dependency->string dep))
+
+   (define dependency-pre-build void)
+   (define dependency-post-build void)])
+
+;; dependency on a file
+(struct file (path)
+  #:transparent
+  #:methods gen:dependency
+  [(define (dependency-modification-timestamp dep)
+     (let ([path (file-path dep)])
+       (and (or (directory-exists? path) (file-exists? path))
+            (file-or-directory-modify-seconds path))))
+
+   (define (dependency->string dep)
+     (let ([path (file-path dep)])
+       (if (path? path)
+           (path->string path)
+           path)))])
+
+;; “phony” / transient dependency
+(struct label (name [timestamp #:mutable])
+  #:transparent
+  #:omit-define-syntaxes
+  #:constructor-name make-label
+  #:methods gen:equal+hash
+  [(define (equal-proc a b equal?)
+     (equal? (label-name a) (label-name b)))
+   (define (hash-proc l hash-code)
+     (hash-code (label-name l)))
+   (define (hash2-proc l hash-code)
+     (hash-code (label-name l)))]
+  #:methods gen:dependency
+  [(define (dependency-modification-timestamp l)
+     (label-timestamp l))
+   (define (dependency-post-build l)
+     (set-label-timestamp! l (current-seconds)))
+   (define (dependency-label l)
+     (label-name l))])
+
+(define (label name)
+  (make-label name #f))


### PR DESCRIPTION
This pull request extends `make` to support arbitrary dependency types in addition to ordinary file dependencies. The specific reason I personally want this is because it lets me make `make` aware of Docker images by doing this:

``` racket
(struct image (tag)
  #:transparent
  #:methods gen:dependency
  [(define (dependency-modification-timestamp i)
     (let* ([out (open-output-string)]
            [exit-code (parameterize ([current-output-port out]
                                      [current-error-port (open-output-nowhere)])
                         (system*/exit-code (find-executable-path "docker")
                                            "inspect" "-f" "{{ .Created }}"
                                            (image-tag i)))]
            [result (string-trim (get-output-string out))])
       (and (zero? exit-code)
            (with-handlers ([exn:fail?
                             (λ (exn)
                               (error 'image "unexpected response from docker daemon: ~v" result))])
              (->posix (iso8601->datetime result))))))

   (define (dependency-label i)
     (image-tag i))])
```

And then I can write `make` targets that produce or depend on docker images:

``` racket
(make
 ([(image "foo/bar") []
    (system "docker pull foo/bar")]
  ["run" [(image "foo/bar")]
    (system "docker run -it foo/bar")])
 (current-command-line-arguments))
```

I implemented this by creating a generic interface, `gen:dependency`, that supports implementing custom dependency types that manage their own timestamp information.

The implementation for this is unfortunately a little bit messy because it needs to preserve backwards compatibility with the existing interface, so things that are passed as strings still need to be treated as file paths. Still, it seems to work from my initial testing with some basic build scripts.

(Also: this repository doesn’t seem to have any tests, but I would be willing to write some simple ones if you tell me where the best place to put them would be.)
